### PR TITLE
Fixed GDAL config error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ elastic-apm==6.6.0
 elastic-app-search==7.10.0
 elasticsearch==7.15.1
 email-validator==1.1.3
-Fiona==1.8.20
+Fiona==1.8.21
 Flask==2.0.2
 Flask-BabelEx==0.9.4
 Flask-Login==0.5.0
@@ -62,7 +62,7 @@ pycparser==2.20
 pygeos==0.12.0
 PyJWT==1.7.1
 pyparsing==2.4.7
-pyproj==3.2.1
+pyproj==3.3
 python-dateutil==2.8.2
 pytz==2021.3
 requests==2.26.0


### PR DESCRIPTION
Fixed below error while running below command

`pip install -r requirements.txt`

```
error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [2 lines of output]
      Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
      A GDAL API version must be specified. Provide a path to gdal-config using a GDAL_CONFIG environment variable or use a GDAL_VERSION environment variable.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```